### PR TITLE
Improve support for dunfell

### DIFF
--- a/recipes-core/meta/wic-tools.bbappend
+++ b/recipes-core/meta/wic-tools.bbappend
@@ -1,0 +1,1 @@
+DEPENDS += "efibootguard-native"


### PR DESCRIPTION
Got the following error message while trying to create an image with
wic on dunfell:

   Wic failed to find a recipe to build native bg_setenv. Please file a bug against wic.

Adding a dependency to bg_setenv-native fixed to issue.

Signed-off-by: Marc Ferland <ferlandm@amotus.ca>