### PR TITLE
Update to efibootguard 0.9

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -17,4 +17,4 @@ BBFILE_COLLECTIONS += "efibootguard"
 BBFILE_PATTERN_efibootguard = "^${LAYERDIR}/"
 BBFILE_PRIORITY_efibootguard = "6"
 
-LAYERSERIES_COMPAT_efibootguard = "rocko sumo thud warrior zeus dunfell"
+LAYERSERIES_COMPAT_efibootguard = "dunfell hardknott honister"

--- a/recipes-bsp/efibootguard/efibootguard_0.9.bb
+++ b/recipes-bsp/efibootguard/efibootguard_0.9.bb
@@ -12,12 +12,17 @@
 LICENSE = "GPLv2"
 LIC_FILES_CHKSUM = "file://COPYING;md5=b234ee4d69f5fce4486a80fdaf4a4263"
 
-SRC_URI = "git://github.com/siemens/efibootguard.git;protocol=https;branch=master"
-SRCREV = "ac1685aea75fb3e3d16c0c0e4f8261a2edb63536"
+SRC_URI = "git://github.com/siemens/efibootguard.git;protocol=https;branch=master \
+    file://0001-Makefile-Fix-static-tool-build-on-incremental-builds.patch \
+    file://0002-Makefile-Fix-static-tool-build-on-incremental-builds.patch \
+    file://0003-Find-pkg-config-on-cross-compilation.patch \
+    file://0004-configure-libpci-detection-optional.patch \
+"
+SRCREV = "c01324d0da202727eb0744c0f67a78f9c9b65c46"
 
 S = "${WORKDIR}/git"
 
-DEPENDS = "gnu-efi pciutils zlib libcheck"
+DEPENDS_class-target = "gnu-efi pciutils zlib libcheck"
 
 inherit autotools deploy pkgconfig
 
@@ -44,8 +49,8 @@ do_deploy () {
 }
 addtask deploy before do_build after do_compile
 
-BBCLASSEXTEND = "native"
 DEPENDS_class-native = "zlib libcheck"
+EXTRA_OECONF_class-native += "--disable-libpci"
 
 do_compile_class-native () {
 	oe_runmake bg_setenv
@@ -59,3 +64,5 @@ do_install_class-native () {
 
 do_deploy_class-native () {
 }
+
+BBCLASSEXTEND = "native"

--- a/recipes-bsp/efibootguard/efibootguard_0.9.bb
+++ b/recipes-bsp/efibootguard/efibootguard_0.9.bb
@@ -52,6 +52,10 @@ addtask deploy before do_build after do_compile
 DEPENDS:class-native = "zlib-native libcheck-native"
 EXTRA_OECONF:class-native += "--disable-libpci"
 
+do_install:append () {
+    rm -f ${D}${libdir}/*.so
+}
+
 do_compile:class-native () {
 	oe_runmake bg_setenv
 }

--- a/recipes-bsp/efibootguard/efibootguard_0.9.bb
+++ b/recipes-bsp/efibootguard/efibootguard_0.9.bb
@@ -22,7 +22,7 @@ SRCREV = "c01324d0da202727eb0744c0f67a78f9c9b65c46"
 
 S = "${WORKDIR}/git"
 
-DEPENDS_class-target = "gnu-efi pciutils zlib libcheck"
+DEPENDS:class-target = "gnu-efi pciutils zlib libcheck"
 
 inherit autotools deploy pkgconfig
 
@@ -38,31 +38,31 @@ EXTRA_OECONF = "--with-gnuefi-sys-dir=${STAGING_DIR_HOST} \
                 --with-gnuefi-include-dir=${STAGING_INCDIR}/efi \
                 --with-gnuefi-lib-dir=${STAGING_LIBDIR}"
 
-FILES_${PN}-tools = "${bindir}"
-FILES_${PN}-tools-dbg = "/usr/src/debug ${bindir}/.debug /usr/lib/debug"
-FILES_${PN}-tools-staticdev = "${libdir}/lib*.a"
-FILES_${PN}-tools-dev = "${includedir}/${BPN}"
-FILES_${PN} = "${libdir}/${BPN}"
+FILES:${PN}-tools = "${bindir}"
+FILES:${PN}-tools-dbg = "/usr/src/debug ${bindir}/.debug /usr/lib/debug"
+FILES:${PN}-tools-staticdev = "${libdir}/lib*.a"
+FILES:${PN}-tools-dev = "${includedir}/${BPN}"
+FILES:${PN} = "${libdir}/${BPN}"
 
 do_deploy () {
 	install ${B}/efibootguard*.efi ${DEPLOYDIR}
 }
 addtask deploy before do_build after do_compile
 
-DEPENDS_class-native = "zlib libcheck"
-EXTRA_OECONF_class-native += "--disable-libpci"
+DEPENDS:class-native = "zlib-native libcheck-native"
+EXTRA_OECONF:class-native += "--disable-libpci"
 
-do_compile_class-native () {
+do_compile:class-native () {
 	oe_runmake bg_setenv
 }
 
-do_install_class-native () {
+do_install:class-native () {
 	install -d ${D}${bindir}/
 	install -m755 ${B}/bg_setenv ${D}${bindir}/
 	ln -s bg_setenv ${D}${bindir}/bg_printenv
 }
 
-do_deploy_class-native () {
+do_deploy:class-native () {
 }
 
 BBCLASSEXTEND = "native"

--- a/recipes-bsp/efibootguard/files/0001-Makefile-Fix-static-tool-build-on-incremental-builds.patch
+++ b/recipes-bsp/efibootguard/files/0001-Makefile-Fix-static-tool-build-on-incremental-builds.patch
@@ -1,0 +1,41 @@
+From ceaa1e98868ab2f0e5a61d069d4c512adcc5037c Mon Sep 17 00:00:00 2001
+From: Christian Storm <christian.storm@siemens.com>
+Date: Tue, 2 Nov 2021 14:22:54 +0100
+Subject: [PATCH 1/4] Makefile: Fix static tool build on incremental builds
+
+On first build, libtool produces a proper statically linked
+bg_setenv tool which by argv[0] decides whether to printenv
+or setenv.
+
+On subsequent builds, e.g., while incrementally developing,
+libtool *dynamically* links bg_setenv against libebgenv and
+applies "magic" [1,2] to compensate for library paths.
+This breaks the bg_setenv argv[0] logic.
+
+So, state explicitly that bg_setenv is to be linked statically.
+
+[1] https://www.gnu.org/software/libtool/manual/html_node/Linking-executables.html#Linking-executables
+[2] https://autotools.io/libtool/wrappers.html
+
+Signed-off-by: Christian Storm <christian.storm@siemens.com>
+Signed-off-by: Jan Kiszka <jan.kiszka@siemens.com>
+---
+ Makefile.am | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/Makefile.am b/Makefile.am
+index 3545ae2..2a5f8f8 100644
+--- a/Makefile.am
++++ b/Makefile.am
+@@ -107,7 +107,7 @@ bg_setenv_SOURCES = \
+ 	tools/bg_setenv.c
+ 
+ bg_setenv_CFLAGS = \
+-	$(AM_CFLAGS)
++	$(AM_CFLAGS) -static
+ 
+ bg_setenv_LDADD = \
+ 	-lebgenv \
+-- 
+2.31.1
+

--- a/recipes-bsp/efibootguard/files/0002-Makefile-Fix-static-tool-build-on-incremental-builds.patch
+++ b/recipes-bsp/efibootguard/files/0002-Makefile-Fix-static-tool-build-on-incremental-builds.patch
@@ -1,0 +1,46 @@
+From fe24f4cf7b8d84a6c928c2d4ee349a7f3080d602 Mon Sep 17 00:00:00 2001
+From: Christian Storm <christian.storm@siemens.com>
+Date: Tue, 2 Nov 2021 22:11:20 +0100
+Subject: [PATCH 2/4] Makefile: Fix static tool build on incremental builds,
+ again
+
+Quoting [1]:
+"We recommend that you avoid using -l options in LDADD or
+ prog_LDADD when referring to libraries built by your package.
+ Instead, write the file name of the library explicitly as in the
+ above cpio example. Use -l only to list third-party libraries. If
+ you follow this rule, the default value of prog_DEPENDENCIES will
+ list all your local libraries and omit the other ones."
+
+Hence, remove bg_setenv_DEPENDENCIES and explicitly specify
+libebgenv.a in bg_setenv_LDADD.
+
+[1] https://www.gnu.org/software/automake/manual/html_node/Linking.html#Linking
+
+Signed-off-by: Christian Storm <christian.storm@siemens.com>
+Signed-off-by: Jan Kiszka <jan.kiszka@siemens.com>
+---
+ Makefile.am | 5 +----
+ 1 file changed, 1 insertion(+), 4 deletions(-)
+
+diff --git a/Makefile.am b/Makefile.am
+index 2a5f8f8..73af2f7 100644
+--- a/Makefile.am
++++ b/Makefile.am
+@@ -110,12 +110,9 @@ bg_setenv_CFLAGS = \
+ 	$(AM_CFLAGS) -static
+ 
+ bg_setenv_LDADD = \
+-	-lebgenv \
++	$(top_builddir)/libebgenv.a \
+ 	-lz
+ 
+-bg_setenv_DEPENDENCIES = \
+-	libebgenv.a
+-
+ install-exec-hook:
+ 	$(AM_V_at)$(LN_S) -f bg_setenv$(EXEEXT) \
+ 		$(DESTDIR)$(bindir)/bg_printenv$(EXEEXT)
+-- 
+2.31.1
+

--- a/recipes-bsp/efibootguard/files/0003-Find-pkg-config-on-cross-compilation.patch
+++ b/recipes-bsp/efibootguard/files/0003-Find-pkg-config-on-cross-compilation.patch
@@ -1,0 +1,35 @@
+From c810c5e32b2faf35351eaebd7df85d17e2916c56 Mon Sep 17 00:00:00 2001
+From: Bastian Germann <bage@debian.org>
+Date: Tue, 7 Dec 2021 03:54:08 +0100
+Subject: [PATCH 3/4] Find pkg-config on cross compilation
+
+PKG_PROG_PKG_CONFIG sets $PKG_CONFIG to a pkg-config executable.
+Setting it manually via AC_PATH_PROG is superfluous and problematic
+with executable name prefixes. Get rid of the AC_PATH_PROG call.
+
+Signed-off-by: Bastian Germann <bage@debian.org>
+Signed-off-by: Jan Kiszka <jan.kiszka@siemens.com>
+---
+ configure.ac | 3 +--
+ 1 file changed, 1 insertion(+), 2 deletions(-)
+
+diff --git a/configure.ac b/configure.ac
+index 6dcd386..01a4fdb 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -174,11 +174,10 @@ AC_ARG_WITH([mem-uservars],
+ AC_DEFINE_UNQUOTED([ENV_MEM_USERVARS], [${ENV_MEM_USERVARS}], [Reserved memory for user variables])
+ 
+ dnl pkg-config
+-AC_PATH_PROG(PKG_CONFIG, pkg-config, no)
++PKG_PROG_PKG_CONFIG()
+ if test "x$PKG_CONFIG" = "xno"; then
+ 	AC_MSG_ERROR([You need to install pkg-config])
+ fi
+-PKG_PROG_PKG_CONFIG()
+ PKG_CHECK_MODULES(LIBCHECK, check)
+ PKG_CHECK_MODULES(LIBPCI, libpci)
+ # ------------------------------------------------------------------------------
+-- 
+2.31.1
+

--- a/recipes-bsp/efibootguard/files/0004-configure-libpci-detection-optional.patch
+++ b/recipes-bsp/efibootguard/files/0004-configure-libpci-detection-optional.patch
@@ -1,0 +1,36 @@
+From 3d3078e10352d845d26c108ebcdf62f3bff0c3fe Mon Sep 17 00:00:00 2001
+From: Adrian Freihofer <adrian.freihofer@siemens.com>
+Date: Tue, 28 Dec 2021 21:11:59 +0000
+Subject: [PATCH 4/4] configure: libpci detection optional
+
+For native builds where only tools are built libpci detection must be
+disabled.
+
+Signed-off-by: Adrian Freihofer <adrian.freihofer@siemens.com>
+---
+ configure.ac | 9 ++++++++-
+ 1 file changed, 8 insertions(+), 1 deletion(-)
+
+diff --git a/configure.ac b/configure.ac
+index 01a4fdb..da15264 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -179,7 +179,14 @@ if test "x$PKG_CONFIG" = "xno"; then
+ 	AC_MSG_ERROR([You need to install pkg-config])
+ fi
+ PKG_CHECK_MODULES(LIBCHECK, check)
+-PKG_CHECK_MODULES(LIBPCI, libpci)
++
++AC_ARG_ENABLE([libpci],
++    AS_HELP_STRING([--disable-libpci], [Disable libpci detection if only tools need to be built]))
++
++AS_IF([test "x$enable_libpci" != "xno"], [
++    PKG_CHECK_MODULES(LIBPCI, libpci)
++])
++
+ # ------------------------------------------------------------------------------
+ AC_CONFIG_FILES([
+ 	Makefile
+-- 
+2.31.1
+

--- a/recipes-core/busybox/busybox_%.bbappend
+++ b/recipes-core/busybox/busybox_%.bbappend
@@ -9,12 +9,12 @@
 # This work is licensed under the terms of the GNU GPL, version 2.
 # See the COPYING.GPLv2 file in the top-level directory.
 
-FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
+FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
 
 SRC_URI += "file://watchdog.cfg \
             file://watchdog.sh"
 
-do_install_append() {
+do_install:append() {
 	install -d "${D}${sysconfdir}/init.d"
 	install -m 0755 "${WORKDIR}/watchdog.sh" "${D}${sysconfdir}/init.d/watchdog.sh"
 	install -d "${D}${sysconfdir}/rcS.d"


### PR DESCRIPTION
Currently both static and dynamic libraries are created for the tools. If I understand it correctly, using dynamic libraries would not work (with version 0.9) because of some implementation details in the bg_* tools. Therefore, this PR only deletes the *.so files for now. (The dynamic libraries also break something in our current implementation.)

However, from my point of view it would make sense to switch to dynamic linking. At least in our case, bg_setenv is not the only binary that is linked against libebgenv. What is planned for the future in this regard?