### PR TITLE
feat(wic-tools): add efibootguard dependency

### DIFF
--- a/recipes-core/meta/wic-tools.bbappend
+++ b/recipes-core/meta/wic-tools.bbappend
@@ -1,1 +1,2 @@
 DEPENDS += "efibootguard-native"
+DEPENDS += "${@'efibootguard' if d.getVar('EFI_PROVIDER') == 'efibootguard' else ''}"


### PR DESCRIPTION
Similar to other EFI_PROVIDER possibilities which are added already in poky

I'm actually not sure which architectures are supported by efibootguard, so we may need to add more archs