### PR TITLE
efibootguard: update 0.11 -> 0.15

### DIFF
--- a/recipes-bsp/efibootguard/efibootguard_0.15.bb
+++ b/recipes-bsp/efibootguard/efibootguard_0.15.bb
@@ -13,12 +13,14 @@ LICENSE = "GPL-2.0-only"
 LIC_FILES_CHKSUM = "file://COPYING;md5=b234ee4d69f5fce4486a80fdaf4a4263"
 SUMMARY = "A bootloader based on UEFI"
 
-SRC_URI = "gitsm://github.com/siemens/efibootguard.git;protocol=https;branch=master"
-SRCREV = "eda1b987f8ca41d64b46f53347a8c89c6fc03c31"
+SRC_URI = "gitsm://github.com/siemens/efibootguard.git;protocol=https;branch=master \
+    file://0001-Use-mgeneral-regs-only-whenever-possible.patch \
+"
+SRCREV = "cc0af9b91e84c15f8cc7acc42df8f2dc595892c2"
 
 S = "${WORKDIR}/git"
 
-DEPENDS:class-target = "gnu-efi pciutils zlib libcheck"
+DEPENDS:class-target = "gnu-efi pciutils zlib libcheck autoconf-archive"
 
 inherit autotools deploy pkgconfig
 
@@ -76,7 +78,7 @@ do_deploy () {
 }
 addtask deploy before do_build after do_compile
 
-DEPENDS:class-native = "zlib-native libcheck-native"
+DEPENDS:class-native = "zlib-native libcheck-native autoconf-archive"
 EXTRA_OECONF:class-native = "--with-gnuefi-sys-dir=${STAGING_DIR_HOST} \
                              --with-gnuefi-include-dir=${STAGING_INCDIR}/efi \
                              --with-gnuefi-lib-dir=${STAGING_LIBDIR} \

--- a/recipes-bsp/efibootguard/files/0001-Use-mgeneral-regs-only-whenever-possible.patch
+++ b/recipes-bsp/efibootguard/files/0001-Use-mgeneral-regs-only-whenever-possible.patch
@@ -1,0 +1,58 @@
+From 261e8c2d5b4d1455f90b2e306afab7ea3705fe27 Mon Sep 17 00:00:00 2001
+From: Jan Kiszka <jan.kiszka@siemens.com>
+Date: Sat, 26 Aug 2023 10:42:28 +0200
+Subject: [PATCH] Use -mgeneral-regs-only whenever possible
+
+This obsoletes explicit no-sse/mmx and resolves build issue with custom
+toolchains on x86, plus it simplifies the setup.
+
+Along that, clarify why we need CFLAGS_MGENERAL_REGS_ONLY.
+
+Upstream-Status: Submitted [https://www.mail-archive.com/efibootguard-dev@googlegroups.com/msg01952.html]
+
+Signed-off-by: Jan Kiszka <jan.kiszka@siemens.com>
+Signed-off-by: Peter Marko <peter.marko@siemens.com>
+---
+ Makefile.am  | 7 +------
+ configure.ac | 1 +
+ 2 files changed, 2 insertions(+), 6 deletions(-)
+
+diff --git a/Makefile.am b/Makefile.am
+index aefdada..02e9cac 100644
+--- a/Makefile.am
++++ b/Makefile.am
+@@ -216,18 +216,13 @@ efi_cflags = \
+ 	-Wsign-compare \
+ 	-DGNU_EFI_USE_MS_ABI \
+ 	-Werror \
++	$(CFLAGS_MGENERAL_REGS_ONLY) \
+ 	$(CFLAGS)
+ 
+ if ARCH_X86_64
+ efi_cflags += \
+-	-mno-sse \
+-	-mno-mmx \
+ 	-mno-red-zone
+ endif
+-if ARCH_ARM
+-efi_cflags += \
+-	$(CFLAGS_MGENERAL_REGS_ONLY)
+-endif
+ 
+ efi_ldflags = \
+ 	-T $(GNUEFI_LIB_DIR)/elf_$(ARCH)_efi.lds \
+diff --git a/configure.ac b/configure.ac
+index d448d71..b000603 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -111,6 +111,7 @@ AC_SUBST([ARCH])
+ AC_SUBST([MACHINE_TYPE_NAME])
+ AM_CONDITIONAL([ARCH_IS_X86], [test "$ARCH" = "ia32" -o "$ARCH" = "x86_64"])
+ 
++# -mgeneral-regs-only was introduced with gcc-9 to ARM, and RISCV64 does not support it until now
+ AX_CHECK_COMPILE_FLAG([-mgeneral-regs-only],
+ 	[CFLAGS_MGENERAL_REGS_ONLY=-mgeneral-regs-only],
+ 	[CFLAGS_MGENERAL_REGS_ONLY=])
+-- 
+2.30.2
+


### PR DESCRIPTION
Fixes CVE-2023-39950

Tested build on kirkstone branch.