### PR TITLE
efibootguard: fix gcc-14 errors on cmalloc

### DIFF
--- a/recipes-bsp/efibootguard/efibootguard/0001-fix-use-correct-order-of-calloc-parameters.patch
+++ b/recipes-bsp/efibootguard/efibootguard/0001-fix-use-correct-order-of-calloc-parameters.patch
@@ -1,0 +1,62 @@
+From 633f5fc6ed48db68744840d07e1272ad25919807 Mon Sep 17 00:00:00 2001
+From: Quirin Gylstorff <quirin.gylstorff@siemens.com>
+Date: Wed, 3 Jul 2024 16:11:36 +0200
+Subject: [PATCH] fix: use correct order of calloc parameters
+
+This fixes a error if compiled with gcc-14. gcc-14 enables the
+compile option `-Werror=calloc-transposed-args`.
+
+No functional change as 1*sizeof(x) is the same as sizeof(x)*1.
+
+Found with Bug#1074932: efibootguard: ftbfs with GCC-14.
+
+Signed-off-by: Quirin Gylstorff <quirin.gylstorff@siemens.com>
+[Jan: style fix]
+Signed-off-by: Jan Kiszka <jan.kiszka@siemens.com>
+
+Upstream-Status: Backport [https://github.com/siemens/efibootguard/commit/633f5fc6ed48db68744840d07e1272ad25919807]
+Signed-off-by: Peter Marko <peter.marko@siemens.com>
+---
+ tools/ebgpart.c | 8 ++++----
+ 1 file changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/tools/ebgpart.c b/tools/ebgpart.c
+index 298d766..f406dcd 100644
+--- a/tools/ebgpart.c
++++ b/tools/ebgpart.c
+@@ -175,7 +175,7 @@ static void read_GPT_entries(int fd, uint64_t table_LBA, uint32_t num,
+ 		}
+ 		VERBOSE(stdout, "%u: %s\n", i, GUID_to_str(e.type_GUID));
+ 
+-		tmpp = calloc(sizeof(PedPartition), 1);
++		tmpp = calloc(1, sizeof(PedPartition));
+ 		if (!tmpp) {
+ 			VERBOSE(stderr, "Out of memory\n");
+ 			return;
+@@ -234,7 +234,7 @@ static void scanLogicalVolumes(int fd, off64_t extended_start_LBA,
+ 					   partition, lognum + 1);
+ 			continue;
+ 		}
+-		partition->next = calloc(sizeof(PedPartition), 1);
++		partition->next = calloc(1, sizeof(PedPartition));
+ 		if (!partition->next) {
+ 			goto scl_out_of_mem;
+ 		}
+@@ -313,7 +313,7 @@ static bool check_partition_table(PedDevice *dev)
+ 					 efihdr.partitions, dev);
+ 			break;
+ 		}
+-		tmp = calloc(sizeof(PedPartition), 1);
++		tmp = calloc(1, sizeof(PedPartition));
+ 		if (!tmp) {
+ 			goto cpt_out_of_mem;
+ 		}
+@@ -449,7 +449,7 @@ void ped_device_probe_all(char *rootdev)
+ 			}
+ 		}
+ 		/* This is a block device, so add it to the list*/
+-		PedDevice *dev = calloc(sizeof(PedDevice), 1);
++		PedDevice *dev = calloc(1, sizeof(PedDevice));
+ 		if (!dev) {
+ 			continue;
+ 		}

--- a/recipes-bsp/efibootguard/efibootguard_0.17.bb
+++ b/recipes-bsp/efibootguard/efibootguard_0.17.bb
@@ -14,6 +14,7 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=b234ee4d69f5fce4486a80fdaf4a4263"
 SUMMARY = "A bootloader based on UEFI"
 
 SRC_URI = "gitsm://github.com/siemens/efibootguard.git;protocol=https;branch=master \
+    file://0001-fix-use-correct-order-of-calloc-parameters.patch \
 "
 SRCREV = "5670b96bffc24e5e23eea5619e1233396f5408e5"
 


### PR DESCRIPTION
This is a preparation for newer hosts, especially Debian 13.
Upgrade will be done for next LTS.
For now only backport patch from newer releases.