### PR TITLE
UKI creation modifications

### DIFF
--- a/recipes-bsp/efibootguard/efibootguard_0.21.bb
+++ b/recipes-bsp/efibootguard/efibootguard_0.21.bb
@@ -95,6 +95,9 @@ do_install:class-native () {
 	install -d ${D}${bindir}/
 	install -m755 ${B}/bg_setenv ${D}${bindir}/
 	ln -s bg_setenv ${D}${bindir}/bg_printenv
+
+    # Install uki creation binary
+    install -m755 ${S}/tools/bg_gen_unified_kernel ${D}${bindir}/
 }
 
 do_install:append() {

--- a/recipes-bsp/efibootguard/efibootguard_0.21.bb
+++ b/recipes-bsp/efibootguard/efibootguard_0.21.bb
@@ -73,6 +73,11 @@ FILES:${PN} += " \
 
 do_deploy () {
 	install ${B}/efibootguard*.efi ${DEPLOYDIR}
+
+    # Deploy kernel stub files
+    if [ -f ${B}/kernel-stub*.efi ]; then
+        install ${B}/kernel-stub*.efi ${DEPLOYDIR}
+    fi
 }
 addtask deploy before do_build after do_compile
 


### PR DESCRIPTION
- Install UKI creation binary in native sysroot to allow bitbake builds to script UKI creation process.
- Deploy kernel stub files since these are needed in the UKI creation. 