### PR TITLE
efibootguard: add aarch64 to COMPATIBLE_HOST

### DIFF
--- a/recipes-bsp/efibootguard/efibootguard_0.22.bb
+++ b/recipes-bsp/efibootguard/efibootguard_0.22.bb
@@ -20,7 +20,7 @@ DEPENDS:class-target = "gnu-efi pciutils zlib libcheck autoconf-archive"
 
 inherit autotools deploy pkgconfig
 
-COMPATIBLE_HOST = "(x86_64.*|i.86.*)-linux"
+COMPATIBLE_HOST = "(x86_64.*|i.86.*|aarch64.*)-linux"
 
 PACKAGES =+ " \
     ${PN}-kernel-stub \


### PR DESCRIPTION
With this change it is possible to build and use efibootguard also on arm64 devices.