### PR TITLE
efibootguard-boot: allow to override kernel parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,4 +72,11 @@ part swap --ondisk mmcblk0 --size 512 --fstype=swap --label swap --align 1024
 bootloader --ptable gpt --append="console=ttyS1,115200n8 reboot=efi,warm rw debugshell=5 rootwait"
 ```
 
+*NOTE*: The `args` source parameter of the `efibootguard-boot` plugin can be
+used to override the kernel command-line arguments per boot partition. When set,
+it replaces the default command line (maps to `bg_setenv --args`):
+```
+part --source efibootguard-boot --size 32 --ondisk mmcblk0 --label boot0 --align 1024 --part-type=0700 --sourceparams "watchdog=60,revision=2,args=root=/dev/mmcblk0p2 console=ttyS0 rw"
+```
+
 *NOTE*: The `--append` option to the bootloader gives kernel parameters that are written into the efibootguard environment file.

--- a/scripts/lib/wic/plugins/source/efibootguard_boot.py
+++ b/scripts/lib/wic/plugins/source/efibootguard_boot.py
@@ -79,7 +79,7 @@ class EfibootguardBootPlugin(SourcePlugin):
         config_cmd = 'bg_setenv -f . -k "C:%s:%s" -a "%s" -r %s -w %s' % \
                       (part.label.upper(), \
                        kernel_dst, \
-                       cmdline.strip(), \
+                       source_params.get("args", cmdline.strip()), \
                        source_params.get("revision", 1), \
                        source_params.get("watchdog", 5))
 


### PR DESCRIPTION
Add an "args" source parameter to allow overriding kernel command-line arguments per boot partition. The parameter name matches the bg_setenv CLI option (-a/--args=KERNEL_ARGS). If not set, the default command line is preserved.

Usage:
  --sourceparams "watchdog=60,revision=2,args=root=/dev/mmcblk0p2 rw"