### PR TITLE
efibootguard: update compatible host list for native variant

### DIFF
--- a/recipes-bsp/efibootguard/efibootguard_0.17.bb
+++ b/recipes-bsp/efibootguard/efibootguard_0.17.bb
@@ -24,6 +24,7 @@ DEPENDS:class-target = "gnu-efi pciutils zlib libcheck autoconf-archive"
 inherit autotools deploy pkgconfig
 
 COMPATIBLE_HOST = "(x86_64.*|i.86.*)-linux"
+COMPATIBLE_HOST:append:class-native = "|aarch64.*-linux"
 
 PACKAGES =+ " \
     ${PN}-kernel-stub \


### PR DESCRIPTION
The efibootguard source code is buildable for aarch64, and the native version works without any issues on the host.

For the moment, aarch64 has been added as a compatible host only for the native variant, because only the native binary has been tested.